### PR TITLE
Prevent open metadata on return

### DIFF
--- a/map_library_dialog_base.ui
+++ b/map_library_dialog_base.ui
@@ -58,6 +58,9 @@
        <property name="text">
         <string>Metadata</string>
        </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -81,6 +84,9 @@
        <property name="text">
         <string>Close</string>
        </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -90,6 +96,9 @@
        </property>
        <property name="text">
         <string>Add</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/metadata.txt
+++ b/metadata.txt
@@ -16,7 +16,10 @@ repository=https://github.com/MarcoDuiker/QGIS_Map_library/
 # Recommended items:
 
 # Uncomment the following line and add your changelog:
-changelog= 0.7: improved error handling, fixed encoding problem on remote qlr with non-ascii characters. 0.8 moved settings to QgsSettings so a global settings file other than QGIS3.ini can be used. 0.9 added the option to disable alphabetical sorting
+changelog=  0.7 improved error handling, fixed encoding problem on remote qlr with non-ascii characters. 
+            0.8 moved settings to QgsSettings so a global settings file other than QGIS3.ini can be used. 
+            0.9 added the option to disable alphabetical sorting.
+            x.x fixed bug, where metadata link was opened when return key was pressed.
 
 # Tags are comma separated with spaces allowed
 tags=maps, layers, wms, wfs, ogr, library


### PR DESCRIPTION
Fixes #4 

@MarcoDuiker  I left the version in the changelog blank for now.