### PR TITLE
Improve result navigation

### DIFF
--- a/map_library.py
+++ b/map_library.py
@@ -710,8 +710,10 @@ class MapLibrary:
         '''
         Shows the settings dialog
         '''
-        # Close main dialog before editing settings dialog to force reload
+        # Close main dialog and reset search string before editing settings dialog to force reload
         self.close_dialog()
+        self.last_search_string = ""
+        self.dlg.search_ldt.setText("")
 
         self.settings_dlg.sort_cbx.setChecked(self.valueToBool(self.settings.value(
             "MapLibrary/sort", True)))

--- a/map_library.py
+++ b/map_library.py
@@ -360,14 +360,17 @@ class MapLibrary:
         return True
     
     def go_to_next_result(self):
-        try:
-            self.search_index = self.search_index + 1
-            self.layerTree.setCurrentItem(
-                self.found_items[self.search_index])
-        except:
-            self.search_index = 0
-            self.layerTree.setCurrentItem(
-                self.found_items[self.search_index])
+        if self.valueToBool(self.settings.value("MapLibrary/filter", False)):
+            self.layerTree.setCurrentItem(self.layerTree.itemBelow(self.layerTree.currentItem()))
+        else:
+            try:
+                self.search_index = self.search_index + 1
+                self.layerTree.setCurrentItem(
+                    self.found_items[self.search_index])
+            except:
+                self.search_index = 0
+                self.layerTree.setCurrentItem(
+                    self.found_items[self.search_index])
 
     def props_from_tree_item(self, item):
         '''
@@ -755,14 +758,7 @@ class MapLibrary:
 
     def on_key_up(self):
         if self.valueToBool(self.settings.value("MapLibrary/filter", False)):
-            try:
-                self.search_index = self.search_index - 1
-                self.layerTree.setCurrentItem(
-                    self.found_items[self.search_index])
-            except:
-                self.search_index = len(self.found_items) - 1
-                self.layerTree.setCurrentItem(
-                    self.found_items[self.search_index])
+            self.layerTree.setCurrentItem(self.layerTree.itemAbove(self.layerTree.currentItem()))
 
     def on_key_down(self):
         if self.valueToBool(self.settings.value("MapLibrary/filter", False)):

--- a/metadata.txt
+++ b/metadata.txt
@@ -22,6 +22,7 @@ changelog=  0.7 improved error handling, fixed encoding problem on remote qlr wi
             1.0 fixed bug, where sort settings could not be read correctly after restart of QGIS.
             1.0 fixed bug, where metadata link was opened when return key was pressed.
             1.0 added the option to filter search results and navigate them with up/down keys.
+            1.1 fixed bug, where some results were skipped when navigating filtered results.
 
 # Tags are comma separated with spaces allowed
 tags=maps, layers, wms, wfs, ogr, library


### PR DESCRIPTION
This fixes a bug where in some cases, depending on the search term, some results are skipped when navigating filtered results. 
Sorry I missed this in my original pull request! 