### PR TITLE
Add relation support for layers in MapLibrary

### DIFF
--- a/libs/example/example.json
+++ b/libs/example/example.json
@@ -7,7 +7,8 @@
             "provider": "qlr", 
             "description": "Bing satellite",
             "keywords": ["Microsoft"],
-            "metadata_url": "https://wikipedia.org/wiki/Bing_Maps"
+            "metadata_url": "https://wikipedia.org/wiki/Bing_Maps",
+            "relation": "id;name;referenced layer;referencing layer;referenced field;refererencing field"
         },
 
         "Google": {

--- a/libs/example/example.json
+++ b/libs/example/example.json
@@ -8,7 +8,7 @@
             "description": "Bing satellite",
             "keywords": ["Microsoft"],
             "metadata_url": "https://wikipedia.org/wiki/Bing_Maps",
-            "relation": "id;name;referenced layer;referencing layer;referenced field;refererencing field"
+            "relations": ["id;name;referenced layer;referencing layer;referenced field;refererencing field"]
         },
 
         "Google": {

--- a/map_library.py
+++ b/map_library.py
@@ -35,7 +35,7 @@ from qgis.PyQt.QtGui import QIcon, QDesktopServices
 from qgis.PyQt.QtWidgets import QAction, QApplication, QTreeWidget, \
                             QTreeWidgetItem, QMessageBox, QDialogButtonBox, \
                             QCompleter, QFileDialog, QTreeWidgetItemIterator
-from qgis.core import Qgis, QgsMessageLog, QgsProject, QgsLayerDefinition, QgsSettings
+from qgis.core import Qgis, QgsMessageLog, QgsProject, QgsLayerDefinition, QgsSettings, QgsRelation
 from qgis.gui import QgsMessageBar
 
 # Initialize Qt resources from file resources.py
@@ -101,7 +101,8 @@ class MapLibrary:
              "provider",        # QGIS layer provider or `qlr` for qlr files
              "on_select_message",# a message shown when the layer is selected
              "on_load_message",  # a message shown when the layer is loaded
-             "metadata_url"     # presented in lib as well as used as identifier
+             "metadata_url",    # presented in lib as well as used as identifier
+             "relation"         # relation definition for the layer, used to create a relation in QGIS
                                 # for the layer in the QGIS metadata tab
         ]                       # first two items are shown in tree
                                 # rest of the items are hidden
@@ -617,6 +618,10 @@ class MapLibrary:
         
         selectedItem = self.layerTree.selectedItems()[0]
         layer_props = self.props_from_tree_item(selectedItem)
+
+        relation = None
+        if hasattr(selectedItem, "layer_props") and isinstance(selectedItem.layer_props, dict):
+            relation = selectedItem.layer_props.get("relation")
         
         QgsMessageLog.logMessage(u'Adding layer ' + str(layer_props), 
                                           'Map Library')
@@ -629,6 +634,12 @@ class MapLibrary:
 
             if layer_props['on_load_message']:
                 self.show_layer_message(layer_props['on_load_message'], 'load')
+
+        if relation:
+            QTimer.singleShot(
+                1000,
+                lambda: self.create_relation(relation)
+    )
                 
             # we might add something here for a "most recent layers" section
             # this should be persistent between sessions, so added to QgsSettings
@@ -642,6 +653,38 @@ class MapLibrary:
                 #settings.setValue("items", TreeWidget.dataFromChild(
                 #                               self.invisibleRootItem()))
                 #settings.endGroup()
+
+    def create_relation(self, relation_string):
+
+        QgsMessageLog.logMessage(
+        f"create_relation: {relation_string}",
+        "Map Library",
+        Qgis.Info
+    )
+
+        manager = QgsProject.instance().relationManager()
+
+        rel_id, rel_name, referenced_layer, referencing_layer, pk, fk = relation_string.split(";")
+
+        # Bereits vorhanden?
+        if manager.relation(rel_id).isValid():
+            return
+
+        referenced = QgsProject.instance().mapLayersByName(referenced_layer)
+        referencing = QgsProject.instance().mapLayersByName(referencing_layer)
+
+        if not referenced or not referencing:
+            return
+
+        relation = QgsRelation()
+        relation.setId(rel_id)
+        relation.setName(rel_name)
+        relation.setReferencedLayer(referenced[0].id())
+        relation.setReferencingLayer(referencing[0].id())
+        relation.addFieldPair(fk, pk)
+
+        if relation.isValid():
+            manager.addRelation(relation)
 
     def show_layer_message(self, message, context):
         '''

--- a/map_library.py
+++ b/map_library.py
@@ -666,7 +666,6 @@ class MapLibrary:
 
         rel_id, rel_name, referenced_layer, referencing_layer, pk, fk = relation_string.split(";")
 
-        # Bereits vorhanden?
         if manager.relation(rel_id).isValid():
             return
 

--- a/map_library.py
+++ b/map_library.py
@@ -102,7 +102,7 @@ class MapLibrary:
              "on_select_message",# a message shown when the layer is selected
              "on_load_message",  # a message shown when the layer is loaded
              "metadata_url",    # presented in lib as well as used as identifier
-             "relation"         # relation definition for the layer, used to create a relation in QGIS
+             "relations"        # relation definitions for the layer, used to create relations in QGIS
                                 # for the layer in the QGIS metadata tab
         ]                       # first two items are shown in tree
                                 # rest of the items are hidden
@@ -619,14 +619,15 @@ class MapLibrary:
         selectedItem = self.layerTree.selectedItems()[0]
         layer_props = self.props_from_tree_item(selectedItem)
 
-        relation = None
-        relation = layer_props.get("relation")
+        relations = []
+        relations = layer_props.get("relations", []) or []
         
         QgsMessageLog.logMessage(u'Adding layer ' + str(layer_props), 
                                           'Map Library')
 
-
-        
+        if isinstance(relations, str):
+            relations = relations.split(",")
+      
         if layer_props:
             if layer_props['provider'].lower() == 'qlr':
                 self.add_layer_by_qlr(layer_props)
@@ -636,10 +637,10 @@ class MapLibrary:
             if layer_props['on_load_message']:
                 self.show_layer_message(layer_props['on_load_message'], 'load')
 
-        if relation:
+        if relations:
             QTimer.singleShot(
                 1000,
-                lambda: self.create_relation(relation)
+                lambda: self.create_relations(relations)
     )
                 
             # we might add something here for a "most recent layers" section
@@ -685,6 +686,11 @@ class MapLibrary:
 
         if relation.isValid():
             manager.addRelation(relation)
+
+
+    def create_relations(self, relations):
+        for relation in relations:
+            self.create_relation(relation)
 
     def show_layer_message(self, message, context):
         '''

--- a/map_library.py
+++ b/map_library.py
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 """
-
 import ast
 import os.path
 import re
@@ -35,8 +34,9 @@ from qgis.PyQt.QtGui import QIcon, QDesktopServices
 from qgis.PyQt.QtWidgets import QAction, QApplication, QTreeWidget, \
                             QTreeWidgetItem, QMessageBox, QDialogButtonBox, \
                             QCompleter, QFileDialog, QTreeWidgetItemIterator
-from qgis.core import Qgis, QgsMessageLog, QgsProject, QgsLayerDefinition, QgsSettings, QgsRelation
+from qgis.core import Qgis, QgsMessageLog, QgsProject, QgsLayerDefinition, QgsSettings, QgsRelation, QgsApplication, QgsEditFormConfig, QgsReadWriteContext
 from qgis.gui import QgsMessageBar
+from qgis.PyQt.QtXml import QDomDocument
 
 # Initialize Qt resources from file resources.py
 from .resources import *
@@ -547,19 +547,25 @@ class MapLibrary:
                                           'Map Library')
             finally:
                 QApplication.restoreOverrideCursor()
-        else:
-            QApplication.restoreOverrideCursor()
-            self.iface.messageBar().pushMessage("Error",
-                self.tr(u'Loading layer failed. '), 
-                self.tr(u'Layer provider "') + layer_props['provider'] + \
-                    self.tr(u'" not supported.'), 
-                level = Qgis.Critical)
-            return
 
+        else:
+            # error message only wehen clicking on layer not on group
+            if layer_props['provider'] != "":
+                QApplication.restoreOverrideCursor()
+                self.iface.messageBar().pushMessage("Error",
+                    self.tr(u'Loading layer failed. '), 
+                    self.tr(u'Layer provider "') + layer_props['provider'] + \
+                        self.tr(u'" not supported.'), 
+                    level = Qgis.Critical)
+                return
+            else:
+                QApplication.restoreOverrideCursor()
+                return
+            
         if not layer or not layer.isValid():
-            self.iface.messageBar().pushMessage("Error",
-                self.tr(u'Loading layer failed. '), 
-                level = Qgis.Critical)
+                    self.iface.messageBar().pushMessage("Error",
+                        self.tr(u'Loading layer failed. '), 
+                        level = Qgis.Critical)
                 
 
     def add_layer_by_qlr(self, layer_props):
@@ -639,10 +645,9 @@ class MapLibrary:
 
         if relations:
             QTimer.singleShot(
-                1000,
+                5000,
                 lambda: self.create_relations(relations)
-    )
-                
+            )             
             # we might add something here for a "most recent layers" section
             # this should be persistent between sessions, so added to QgsSettings
             # dataFromChild()
@@ -655,42 +660,84 @@ class MapLibrary:
                 #settings.setValue("items", TreeWidget.dataFromChild(
                 #                               self.invisibleRootItem()))
                 #settings.endGroup()
-
+                
     def create_relation(self, relation_string):
 
         QgsMessageLog.logMessage(
-        f"create_relation: {relation_string}",
-        "Map Library",
-        Qgis.Info
-    )
+            f"create_relation: {relation_string}",
+            "Map Library",
+            Qgis.Info
+        )
+
+        parts = relation_string.split(";")
+        if len(parts) != 6:
+            QgsMessageLog.logMessage(
+                f"Invalid relation definition: {relation_string}",
+                "Map Library",
+                Qgis.Warning
+            )
+            return
+
+        rel_id, rel_name, referenced_layer_name, referencing_layer_name, pk, fk = parts
 
         manager = QgsProject.instance().relationManager()
-
-        rel_id, rel_name, referenced_layer, referencing_layer, pk, fk = relation_string.split(";")
 
         if manager.relation(rel_id).isValid():
             return
 
-        referenced = QgsProject.instance().mapLayersByName(referenced_layer)
-        referencing = QgsProject.instance().mapLayersByName(referencing_layer)
+        referenced_layers = QgsProject.instance().mapLayersByName(referenced_layer_name)
+        referencing_layers = QgsProject.instance().mapLayersByName(referencing_layer_name)
 
-        if not referenced or not referencing:
+        if not referenced_layers or not referencing_layers:
+            QgsMessageLog.logMessage(
+                f"Layer of relation '{rel_name}' couldn't be found.",
+                "Map Library",
+                Qgis.Warning
+            )
             return
+
+        referenced = referenced_layers[0]
+        referencing = referencing_layers[0]
 
         relation = QgsRelation()
         relation.setId(rel_id)
         relation.setName(rel_name)
-        relation.setReferencedLayer(referenced[0].id())
-        relation.setReferencingLayer(referencing[0].id())
+        relation.setReferencedLayer(referenced.id())
+        relation.setReferencingLayer(referencing.id())
         relation.addFieldPair(fk, pk)
 
-        if relation.isValid():
-            manager.addRelation(relation)
+        if not relation.isValid():
+            QgsMessageLog.logMessage(
+                f"Relation '{rel_name}' ist ungültig.",
+                "Map Library",
+                Qgis.Warning
+            )
+            return
 
+        manager.addRelation(relation)
 
+        self.refresh_relation_widgets(referenced)
+            
     def create_relations(self, relations):
+        
         for relation in relations:
             self.create_relation(relation)
+
+    def refresh_relation_widgets(self, layer):
+
+        form_config = layer.editFormConfig()
+
+        doc = QDomDocument()
+        context = QgsReadWriteContext()
+
+        form_config.writeXml(doc, context)
+
+        new_cfg = QgsEditFormConfig()
+        new_cfg.readXml(doc, context)
+
+        layer.setEditFormConfig(new_cfg)
+        layer.setEditFormConfig(form_config)
+        layer.triggerRepaint()
 
     def show_layer_message(self, message, context):
         '''

--- a/map_library.py
+++ b/map_library.py
@@ -620,11 +620,12 @@ class MapLibrary:
         layer_props = self.props_from_tree_item(selectedItem)
 
         relation = None
-        if hasattr(selectedItem, "layer_props") and isinstance(selectedItem.layer_props, dict):
-            relation = selectedItem.layer_props.get("relation")
+        relation = layer_props.get("relation")
         
         QgsMessageLog.logMessage(u'Adding layer ' + str(layer_props), 
                                           'Map Library')
+
+
         
         if layer_props:
             if layer_props['provider'].lower() == 'qlr':


### PR DESCRIPTION
Some of the qlr layers we provide rely on relations between layers (e.g. to use relation reference widgets in attribute forms). 
With this change, relations can be defined directly in the corresponding contents JSON file using the optional "relation" property.

When a layer is loaded through the MapLibrary plugin, the plugin reads this property and automatically creates the corresponding QGIS project relation, provided that the referenced layers are available in the project.